### PR TITLE
Current version doesn't include request method in canonical_string

### DIFF
--- a/api_auth.js
+++ b/api_auth.js
@@ -29,8 +29,7 @@ exports.auth = function(access_id, secret) {
     var content_md5 = crypto.createHash('md5').update(content_body).digest('base64');
     var date = moment().utc().format('ddd, DD MMM YYYY HH:mm:ss') + ' GMT';
 
-    var canonical_string = [options.method,content_type, content_md5, path, date].join();
-    console.log(canonical_string);
+    var canonical_string = [options.method, content_type, content_md5, path, date].join();
 
     var auth_header_value = 'APIAuth ' + this.access_id + ':' + crypto.createHmac('sha1', this.secret).update(canonical_string).digest('base64');
 

--- a/api_auth.js
+++ b/api_auth.js
@@ -29,7 +29,8 @@ exports.auth = function(access_id, secret) {
     var content_md5 = crypto.createHash('md5').update(content_body).digest('base64');
     var date = moment().utc().format('ddd, DD MMM YYYY HH:mm:ss') + ' GMT';
 
-    var canonical_string = [content_type, content_md5, path, date].join();
+    var canonical_string = [options.method,content_type, content_md5, path, date].join();
+    console.log(canonical_string);
 
     var auth_header_value = 'APIAuth ' + this.access_id + ':' + crypto.createHmac('sha1', this.secret).update(canonical_string).digest('base64');
 
@@ -47,4 +48,3 @@ function isEmpty(value)
 {
   return value === null || value === '' || typeof value === 'undefined';
 }
-


### PR DESCRIPTION
I realise this is 7 years old at this point! But I used this for a project and found it very helpful, I had to do a bit of reverse engineering to make it work though, and noticed that the rails library now includes the request method in the `canonical_string`. 

In order to make this client work out of the box you just need to include this when signing requests. 